### PR TITLE
Fix many-to-many field migration

### DIFF
--- a/aldryn_news/models.py
+++ b/aldryn_news/models.py
@@ -243,7 +243,7 @@ class LatestNewsPlugin(CMSPlugin):
         return str(self.latest_entries)
 
     def copy_relations(self, oldinstance):
-        self.tags = oldinstance.tags.all()
+        self.tags.set(oldinstance.tags.all())
 
     def get_news(self):
         news = News.published.language(self.language).get_published().select_related('category')


### PR DESCRIPTION
[Django CMS Copy Explanation](http://docs.django-cms.org/en/latest/how_to/custom_plugins.html)

erro msg ori:

```
TypeError
Direct assignment to the forward side of a many-to-many set is prohibited. Use tags.set() instead.
```